### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
   release-adapter:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,4 +12,4 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2

--- a/Source/VerveAdapter.swift
+++ b/Source/VerveAdapter.swift
@@ -13,19 +13,27 @@ final class VerveAdapter: PartnerAdapter {
     private let APP_TOKEN_KEY: String = "app_token"
 
     /// The version of the partner SDK.
-    let partnerSDKVersion = HyBid.sdkVersion() ?? "Unknown"  // SDK returns an optional string
-    
+    var partnerSDKVersion: String {
+        VerveAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.2.21.0.0"
-    
+    var adapterVersion: String {
+        VerveAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "verve"
-    
+    var partnerID: String {
+        VerveAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "Verve"
-    
+    var partnerDisplayName: String {
+        VerveAdapterConfiguration.partnerDisplayName
+    }
+
     /// The designated initializer for the adapter.
     /// Chartboost Mediation SDK will use this constructor to create instances of conforming types.
     /// - parameter storage: An object that exposes storage managed by the Chartboost Mediation SDK to the adapter.

--- a/Source/VerveAdapterConfiguration.swift
+++ b/Source/VerveAdapterConfiguration.swift
@@ -10,20 +10,20 @@ import HyBid
 @objc public class VerveAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         HyBid.sdkVersion() ?? ""
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.2.21.0.0"
+    @objc public static let adapterVersion = "4.2.21.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "verve"
+    @objc public static let partnerID = "verve"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "Verve"
+    @objc public static let partnerDisplayName = "Verve"
 
     // A mapping of HyBid log levels to an externally-visible type for publishers to use when configuring this adapter
     @objc public enum VerveLogLevel: Int {

--- a/Source/VerveAdapterConfiguration.swift
+++ b/Source/VerveAdapterConfiguration.swift
@@ -9,6 +9,22 @@ import HyBid
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
 @objc public class VerveAdapterConfiguration: NSObject {
 
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        HyBid.sdkVersion() ?? ""
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.2.21.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "verve"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "Verve"
+
     // A mapping of HyBid log levels to an externally-visible type for publishers to use when configuring this adapter
     @objc public enum VerveLogLevel: Int {
         case none = 0


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.