### PR TITLE
Early merge of main into release/5.x.x.x.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Adapters are compatible with any Chartboost Mediation SDK version within that ma
 - This version of the adapter has been certified with ChartboostMediationSDK 5.0.0.
 - This version of the adapter has been certified with HyBid 2.21.0.
 
+### 4.3.0.0.0
+- The minimum OS version required is now iOS 12.0.
+- This version of the adapter has been certified with HyBid 3.0.0.
+
 ### 4.2.21.0.0
 - This version of the adapter has been certified with HyBid 2.21.0.
 

--- a/ChartboostMediationAdapterVerve.podspec
+++ b/ChartboostMediationAdapterVerve.podspec
@@ -1,6 +1,6 @@
   Pod::Spec.new do |spec|
     spec.name        = 'ChartboostMediationAdapterVerve'
-    spec.version     = '5.2.21.0.0'
+    spec.version     = '5.3.0.0.0'
     spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
     spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-verve'
     spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -24,7 +24,7 @@
     spec.dependency 'ChartboostMediationSDK', '~> 5.0'
 
     # Partner network SDK and version that this adapter is certified to work with.
-    spec.dependency 'HyBid', '~> 2.21.0'
+    spec.dependency 'HyBid', '~> 3.0.0'
 
     # Indicates, that if use_frameworks! is specified, the pod should include a static library framework.
     spec.static_framework = true

--- a/Source/VerveAdapterConfiguration.swift
+++ b/Source/VerveAdapterConfiguration.swift
@@ -18,7 +18,7 @@ import HyBid
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc public static let adapterVersion = "4.2.21.0.0"
+    @objc public static let adapterVersion = "4.3.0.0.0"
 
     /// The partner's unique identifier.
     @objc public static let partnerID = "verve"


### PR DESCRIPTION
Merge of main into release/5.x.x.x.. Adapter version strings may or may not be up to date, they need to be changed once we finalize the partner version to release the 5.x adapters with anyway.