### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All official releases can be found on this repository's [releases page](https://
 
 ## Mediation 4
 
+### 4.3.1.0.0
+- This version of the adapter has been certified with HyBid 3.1.0.
+
 ### 4.3.0.0.0
 - The minimum OS version required is now iOS 12.0.
 - This version of the adapter has been certified with HyBid 3.0.0.


### PR DESCRIPTION
Updated CHANGELOG to include `4.3.1.0.0`. 

 Sister PR for https://github.com/ChartBoost/helium-ios/pull/2190.  This one is needed so that the CHANGELOG is up to date *now* instead of waiting for the next 5.x release.